### PR TITLE
Add High Resolution Texture Pack ESM

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -270,6 +270,15 @@ plugins:
       - 'DLCCoast.esm'
       - 'DLCworkshop02.esm'
       - 'DLCworkshop03.esm'
+  - name: 'DLCUltraHighResolution.esm'
+    global_priority: -120
+    after:
+      - 'DLCRobot.esm'
+      - 'DLCworkshop01.esm'
+      - 'DLCCoast.esm'
+      - 'DLCworkshop02.esm'
+      - 'DLCworkshop03.esm'
+      - 'DLCNukaWorld.esm'
 
   ### Patches
   - name: 'Unofficial Fallout 4 Patch.esp'


### PR DESCRIPTION
Adds the official texture pack ESM (not that there's anything in it) right after the other official DLC.

I don't know how Github works.